### PR TITLE
Run lint and unit tests on focal container

### DIFF
--- a/.github/workflows/lint-unit.yaml
+++ b/.github/workflows/lint-unit.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   lint-unit:
     name: Lint and Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
We are running lint and unit tests with pythons
* `3.6`
* `3.8` 
* `3.10`

current image for `ubuntu-latest` is jammy which does not support `3.6`. Switching to using `ubuntu-20.04` image should allow us to run all three interpreters.