### PR TITLE
Set juju controller to 3.4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -27,6 +27,10 @@ jobs:
 
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
+    needs: lint-unit
+    strategy:
+      fail-fast: false
+      matrix:
         series: ["focal", "jammy"]
     with:
       command: FUNC_ARGS="--series ${{ matrix.series }}" make functional

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,16 +22,29 @@ jobs:
       tox-version: '<4'
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
+    name: Functional tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
     needs: lint-unit
     strategy:
       fail-fast: false
       matrix:
-        series: ["focal", "jammy"]
-    with:
-      command: FUNC_ARGS="--series ${{ matrix.series }}" make functional
-      juju-channel: '3.1/stable'
-      nested-containers: true
-      python-version: '3.10'
-      timeout-minutes: 120
-      tox-version: '<4'
+        series: ['focal', 'jammy']
+        juju-channel: ['3.4/stable']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Setup Juju ${{ matrix.juju-channel }} LXD environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: ${{ matrix.juju-channel }}
+      - name: Show juju information
+        run: |
+          juju version
+          juju controllers | grep Version -A 1 | awk '{print $9}'
+      - name: Run functional test
+        run: FUNC_ARGS='--series ${{ matrix.series }}' make functional

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,29 +26,11 @@ jobs:
       tox-version: '<4'
 
   func:
-    name: Functional tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    needs: lint-unit
-    strategy:
-      fail-fast: false
-      matrix:
-        series: ['focal', 'jammy']
-        juju-channel: ['3.4/stable']
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Setup Juju ${{ matrix.juju-channel }} LXD environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-          juju-channel: ${{ matrix.juju-channel }}
-      - name: Show juju information
-        run: |
-          juju version
-          juju controllers | grep Version -A 1 | awk '{print $9}'
-      - name: Run functional test
-        run: FUNC_ARGS='--series ${{ matrix.series }}' make functional
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
+        series: ["focal", "jammy"]
+    with:
+      command: FUNC_ARGS="--series ${{ matrix.series }}" make functional
+      juju-channel: '3.4/stable'
+      nested-containers: true
+      python-version: '3.10'
+      timeout-minutes: 120

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,6 +10,10 @@ on:
       - '**.md'
       - '**.rst'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ unittests:
 	@tox -e unit -- ${UNIT_ARGS}
 
 functional:
-	@echo "Executing functional tests with args: ${FUNC_ARGS}"
-	@tox -e func -- ${FUNC_ARGS}
+	@echo "Executing functional tests using built charm at ${PROJECTPATH}"
+	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
 
 test: lint unittests functional
 	@echo "Tests completed for charm ${CHARM_NAME}."

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ unittests:
 	@tox -e unit -- ${UNIT_ARGS}
 
 functional:
-	@echo "Executing functional tests using built charm at ${PROJECTPATH}"
-	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
+	@echo "Executing functional tests with args: ${FUNC_ARGS}"
+	@tox -e func -- ${FUNC_ARGS}
 
 test: lint unittests functional
 	@echo "Tests completed for charm ${CHARM_NAME}."


### PR DESCRIPTION
Make the functional test pass by setting the controller channel to 3.4. Add workflow concurrency to prevent multiple workflows from running together on a single pull request.