### PR TITLE
Update tics workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -234,7 +234,7 @@ jobs:
           path: "${{ env.CRASHDUMPS_DIR }}/juju-crashdump-*.tar.xz"
 
   tics-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
     if: >
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
@@ -246,7 +246,21 @@ jobs:
 
       - name: Install coverage tools
         run: |
-          pip install coverage
+          pip install coverage[toml]
+
+      # Install everything from all requirements.txt files otherwise TICS errors.
+      - name: Install all charm dependencies
+        run: |
+          for f in $(find -name '*requirements.txt'); do
+              echo "${f}"
+              pip3 install --requirement "${f}"
+          done
+
+          # For reactive charms
+          for f in $(find -name 'wheelhouse.txt'); do
+              echo "${f}"
+              pip3 install --requirement "${f}"
+          done
 
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
@@ -263,15 +277,19 @@ jobs:
         run: |
           # Create the path that is expected to have a coverage.xml for tics
           mkdir -p tests/report/
+
           coverage_files=(./artifacts/.coverage*)
+
           if [ -e "${coverage_files[0]}" ]; then
             echo "Merging coverage files: ${coverage_files[*]}"
             coverage combine "${coverage_files[@]}"
-            coverage xml -o tests/report/coverage.xml
-          else
-            echo "No coverage files found, skipping merge"
-            # Create an empty file to avoid downstream failure
-            touch tests/report/coverage.xml
+
+            # Check if there is actual data to report before generating XML with merged reports
+            if coverage report > /dev/null 2>&1; then
+              coverage report --show-missing
+              coverage xml -o tests/report/coverage.xml
+            fi
+
           fi
 
       - name: Run TICS analysis


### PR DESCRIPTION
charm-simple-streams doesn't use the automation tool for updating the check.yaml.

This is updating the tics workflow in order to fix some know issues:

- install dependencies
- use the self-hosted runner